### PR TITLE
Instant search fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.oex
 *.user.js
+/opera/icons/*
+/opera/includes/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.oex
+*.user.js

--- a/Rakefile
+++ b/Rakefile
@@ -3,14 +3,14 @@ require 'jspp'
 require 'colored'
 require 'zip/zip'
 
-VERSION = '1.9'
+EXTENSION_VERSION = '1.9'
 
 NAME = 'faviconize-google.user.js'
 CHROME_EXTENSION = 'chrome/faviconize-google.user.js'
 SAFARI_EXTENSION = 'Faviconize Google.safariextension'
 OPERA_ICONS_DIR = 'opera/icons'
 OPERA_INCLUDES_DIR = 'opera/includes'
-OPERA_EXTENSION = "FaviconizeGoogle-#{VERSION}.oex"
+OPERA_EXTENSION = "FaviconizeGoogle-#{EXTENSION_VERSION}.oex"
 
 task :default => :userjs
 task :userjs do

--- a/chrome/userscript.js
+++ b/chrome/userscript.js
@@ -5,7 +5,7 @@
 // @include      http://www.google.*/search?*
 // @include      https://encrypted.google.*/search?*
 // @include      http://www.google.*/webhp*
-// @include      http://www.google.*/#*
+// @include      http://www.google.*/
 // @include      http://groups.google.*/groups/search?* 
 // @copyright    2009+, Nikita Vasilyev (http://userscripts.org/scripts/show/58177)
 // @version      1.9


### PR DESCRIPTION
It seems that Opera doesn't understand the /#\* URL in UserJS header, so this extenstion was not working with instant search.
